### PR TITLE
Tighten run exports pinning

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -16,7 +16,7 @@ source:
     - patches/0001-do-not-look-for-f2c-on-windows.patch
 
 build:
-  number: 8
+  number: 9
 
 outputs:
   - package:
@@ -58,7 +58,7 @@ outputs:
           then: libcxx
         - eigen
       run_exports:
-        - ${{ pin_subpackage('libvisp', upper_bound='x.x') }}
+        - ${{ pin_subpackage('libvisp', upper_bound='x.x.x') }}
     tests:
       - package_contents:
           include:


### PR DESCRIPTION
As discussed with upstream dev @fspindle and @rolalaro, ViSP ABI stability won't be guaranteed to follow `x.x` version schema in the future, especially with the incoming patched release 3.7.1.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
